### PR TITLE
Fix verbose param

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,6 @@ runs:
       run: |
         : extract
         archive="${{ steps.setup.outputs.archive }}"
-        verbose="${{ inputs.verbose }}"
         ls -l $archive
         if [ -s $archive ]; then
             sudo tar -C / -P -x${{ inputs.verbose && 'v' || '' }}zf $archive

--- a/action.yml
+++ b/action.yml
@@ -68,10 +68,8 @@ runs:
         archive="${{ steps.setup.outputs.archive }}"
         verbose="${{ inputs.verbose }}"
         ls -l $archive
-        if [ -s $archive ]
-        then
-            [ "$verbose" = true ] && tar -tvzf $archive
-            sudo tar -C / -P -xvzf $archive
+        if [ -s $archive ]; then
+            sudo tar -C / -P -x${{ inputs.verbose && 'v' || '' }}zf $archive
         else
             echo "$archive is empty"
         fi


### PR DESCRIPTION
If verbose is off, the "v" string should not be passed to `tar`.

I was trying to debug my [postgis-installing](https://github.com/nyurik/action-setup-postgis) action (via homebrew), and I noticed the `verbose` param is not being processed -- the logs are enormous (see any of the failed actions).

Also, I could not find input "types" support in [github docs](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action) -- are you sure "boolean" is actually a type?  (it is supported for custom workflows, but not for actions it seems. Also stackoverflow states [the same](https://stackoverflow.com/questions/76292948/github-action-boolean-input-with-default-value)).